### PR TITLE
Exclude hidden layers

### DIFF
--- a/plugin/plugin.ts
+++ b/plugin/plugin.ts
@@ -18,8 +18,6 @@ body {
 
 // Cause our plugin to show
 figma.showUI(html, { width: 400, height: 400 });
-// Inside instances, skip over invisible nodes and their descendants for speed.
-figma.skipInvisibleInstanceChildren = true;
 
 console.log("This in plugin:", globalThis);
 

--- a/plugin/plugin.ts
+++ b/plugin/plugin.ts
@@ -18,6 +18,8 @@ body {
 
 // Cause our plugin to show
 figma.showUI(html, { width: 400, height: 400 });
+// Inside instances, skip over invisible nodes and their descendants for speed.
+figma.skipInvisibleInstanceChildren = true;
 
 console.log("This in plugin:", globalThis);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,16 +63,19 @@ function isVisible(n: any) {
     return true;
   }
 
-  return n.visible && n.opacity > 0 && !n.removed;
+  return n.visible && n.opacity > 0.001 && !n.removed;
 }
 
 export async function dump(
   n: readonly SceneNode[],
-  skipInvisibleNodes: boolean = true
+  options: { skipInvisibleNodes: boolean } = { skipInvisibleNodes: true }
 ): Promise<F.DumpedFigma> {
   type AnyObject = { [name: string]: any };
+  const { skipInvisibleNodes } = options;
 
-  // If skipInvisibleNodes is true, skip invisible nodes/their descendants inside instances.
+  // Capture original value in case we change it.
+  const oldSkipInvisibleInstanceChildren = figma.skipInvisibleInstanceChildren;
+  // If skipInvisibleNodes is true, skip invisible nodes/their descendants inside *instances*.
   // This only covers instances, and doesn't consider opacity etc.
   // We could filter out these nodes ourselves but it's more efficient when
   // Figma doesn't include them in in the first place.
@@ -141,7 +144,7 @@ export async function dump(
   const images = Object.fromEntries(await Promise.all(dataRequests));
 
   // Reset skipInvisibleInstanceChildren to not affect other code.
-  figma.skipInvisibleInstanceChildren = false;
+  figma.skipInvisibleInstanceChildren = oldSkipInvisibleInstanceChildren;
 
   return {
     objects,


### PR DESCRIPTION
## Changes

- Excludes hidden layers by using [skipInvisibleInstanceChildren](https://www.figma.com/plugin-docs/api/properties/figma-skipinvisibleinstancechildren/) and manually checking if a node isn't hidden, has a non-zero opacity, and hasn't been [removed](https://www.figma.com/plugin-docs/api/properties/nodes-removed/)
- This cut down the final JSON size by 65% when I tested it on a random internal design

## Test plan

- Manually verified that we only exclude hidden SceneNodes by studying the figma-json output and hiding/showing layers to see what changes
- Will add tests soon when we add the other tests for this package