### PR TITLE
Update incorrect removed and geometry types

### DIFF
--- a/src/figma-default-layers.ts
+++ b/src/figma-default-layers.ts
@@ -16,7 +16,6 @@ const defaultLayers: {
   RECTANGLE: {
     id: "_",
     name: "Rectangle",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -88,7 +87,6 @@ const defaultLayers: {
   LINE: {
     id: "_",
     name: "Line",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -150,7 +148,6 @@ const defaultLayers: {
   ELLIPSE: {
     id: "_",
     name: "Ellipse",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -219,7 +216,6 @@ const defaultLayers: {
   POLYGON: {
     id: "_",
     name: "Polygon",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -284,7 +280,6 @@ const defaultLayers: {
   STAR: {
     id: "_",
     name: "Star",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -350,7 +345,6 @@ const defaultLayers: {
   VECTOR: {
     id: "_",
     name: "Vector",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -411,7 +405,6 @@ const defaultLayers: {
   TEXT: {
     id: "_",
     name: "Text",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -492,7 +485,6 @@ const defaultLayers: {
   FRAME: {
     id: "_",
     name: "Frame",
-    removed: false,
     visible: true,
     locked: false,
     componentPropertyReferences: null,
@@ -603,7 +595,6 @@ const defaultLayers: {
   PAGE: {
     id: "_",
     name: "Page",
-    removed: false,
     children: [],
     guides: [],
     selection: [],

--- a/src/figma-json.ts
+++ b/src/figma-json.ts
@@ -638,7 +638,8 @@ export interface BaseNodeMixin extends PluginDataMixin {
   // CONVERSION: important to not have parent because we have nesting
   // readonly parent: (BaseNode & ChildrenMixin) | null;
   name: string; // Note: setting this also sets `autoRename` to false on TextNodes
-  readonly removed: boolean;
+  // CONVERSION: excluding removed because it doesn't provide value
+  // readonly removed: boolean;
   // TODO: Add relaunch data?
 }
 
@@ -681,7 +682,8 @@ export interface ConstraintMixin {
 export interface LayoutMixin {
   // CONVERSION: should we use absoluteBounds?
   // readonly absoluteTransform: Transform;
-  relativeTransform: Transform;
+  // CONVERSION: relativeTransform's presence depends on the `geometry` option
+  relativeTransform?: Transform;
   x: number;
   y: number;
   rotation: number; // In degrees
@@ -726,7 +728,8 @@ export interface MinimalStrokesMixin {
   strokeJoin: StrokeJoin | Mixed;
   strokeAlign: "CENTER" | "INSIDE" | "OUTSIDE";
   dashPattern: ReadonlyArray<number>;
-  strokeGeometry: VectorPaths;
+  // CONVERSION: strokeGeometry's presence depends on the `geometry` option
+  strokeGeometry?: VectorPaths;
 }
 
 export interface IndividualStrokesMixin {
@@ -744,7 +747,8 @@ export interface MinimalFillsMixin {
 export interface GeometryMixin extends MinimalStrokesMixin, MinimalFillsMixin {
   strokeCap: StrokeCap | Mixed;
   strokeMiterLimit: number;
-  fillGeometry: VectorPaths;
+  // CONVERSION: fillGeometry's presence depends on the `geometry` option
+  fillGeometry?: VectorPaths;
 }
 
 export interface CornerMixin {
@@ -852,7 +856,8 @@ export interface OpaqueNodeMixin
     SceneNodeMixin,
     ExportMixin {
   // readonly absoluteTransform: Transform;
-  relativeTransform: Transform;
+  // CONVERSION: relativeTransform's presence depends on the `geometry` option
+  relativeTransform?: Transform;
   x: number;
   y: number;
   readonly width: number;


### PR DESCRIPTION
## Changes

- Removes `removed` from types [because we added it to the blacklist](https://github.com/darknoon/figma-json-plugin/pull/20)
- Marks all geometry keys as optional [because we introduced a `geometry` option that sometimes excludes them](https://github.com/darknoon/figma-json-plugin/pull/21)
- Updates default layers to reflect the new types

## Test plan

- Verified that all tests run/there are no TS issues/plugin still works