### PR TITLE
Fix inability to insert with fills

### DIFF
--- a/src/figma-default-layers.ts
+++ b/src/figma-default-layers.ts
@@ -556,20 +556,6 @@ const defaultLayers: {
     strokeRightWeight: 1,
     layoutGrids: [],
     gridStyleId: "",
-    backgrounds: [
-      {
-        type: "SOLID",
-        visible: true,
-        opacity: 1,
-        blendMode: "NORMAL",
-        color: {
-          r: 1,
-          g: 1,
-          b: 1
-        }
-      }
-    ],
-    backgroundStyleId: "",
     clipsContent: true,
     guides: [],
     expanded: true,

--- a/src/figma-json.ts
+++ b/src/figma-json.ts
@@ -718,8 +718,10 @@ export interface BlendMixin extends MinimalBlendMixin {
 
 export interface ContainerMixin {
   expanded: boolean;
-  backgrounds: ReadonlyArray<Paint>; // DEPRECATED: use 'fills' instead
-  backgroundStyleId: string; // DEPRECATED: use 'fillStyleId' instead
+  // DEPRECATED: use 'fills' instead
+  // backgrounds: ReadonlyArray<Paint>;
+  // DEPRECATED: use 'fillStyleId' instead
+  // backgroundStyleId: string;
 }
 
 export type StrokeCap =

--- a/src/readBlacklist.test.ts
+++ b/src/readBlacklist.test.ts
@@ -60,3 +60,31 @@ test.each(TestMatrix)(
     expect(fn(l, opts)).toContain("componentPropertyDefinitions");
   }
 );
+
+describe("exclude deprecated background properties for all nodes but page", () => {
+  test.each(TestMatrix)(
+    "page has background properties ($name) geom = $opts.geometry",
+    ({ fn, opts }) => {
+      const l = { type: "PAGE" };
+      expect(fn(l, opts)).not.toContain("backgrounds");
+      expect(fn(l, opts)).not.toContain("backgroundStyleId");
+    }
+  );
+
+  test.each(TestMatrix)(
+    "non-page nodes don't have background properties ($name) geom = $opts.geometry",
+    ({ fn, opts }) => {
+      const t = { type: "TEXT" };
+      expect(fn(t, opts)).toContain("backgrounds");
+      expect(fn(t, opts)).toContain("backgroundStyleId");
+
+      const cs = { type: "COMPONENT_SET" };
+      expect(fn(cs, opts)).toContain("backgrounds");
+      expect(fn(cs, opts)).toContain("backgroundStyleId");
+
+      const f = { type: "FRAME" };
+      expect(fn(f, opts)).toContain("backgrounds");
+      expect(fn(f, opts)).toContain("backgroundStyleId");
+    }
+  );
+});

--- a/src/readBlacklist.ts
+++ b/src/readBlacklist.ts
@@ -30,26 +30,40 @@ export const readBlacklist = new Set([
 
 const _tooManyPoints = ["fillGeometry", "strokeGeometry"];
 const _relativeTransformEtc = ["size", "relativeTransform"];
+const _backgrounds = ["backgrounds", "backgroundStyleId"];
 const _defaultBlacklist = new Set([
   ...readBlacklist,
   "componentPropertyDefinitions"
 ]);
-const _noGeometryBlacklist = new Set([..._defaultBlacklist, ..._tooManyPoints]);
+const _defaultBlacklistNoBackgrounds = new Set([
+  ..._defaultBlacklist,
+  ..._backgrounds
+]);
 
-const _okToReadDefsWithGeomBlacklist = new Set([...readBlacklist]);
+const _noGeometryBlacklist = new Set([..._defaultBlacklist, ..._tooManyPoints]);
+const _noGeometryNoBackgroundsBlacklist = new Set([
+  ..._noGeometryBlacklist,
+  ..._backgrounds
+]);
+
+const _okToReadDefsWithGeomBlacklist = new Set([
+  ...readBlacklist,
+  ..._backgrounds
+]);
 const _okToReadDefsNoGeomBlacklist = new Set([
   ...readBlacklist,
-  _tooManyPoints
+  ..._tooManyPoints,
+  ..._backgrounds
 ]);
 const _textLayerNoGeomBlacklist = new Set([
-  ..._defaultBlacklist,
+  ..._defaultBlacklistNoBackgrounds,
   ..._tooManyPoints,
   ..._relativeTransformEtc
 ]);
 
 const _textLayerWithGeomBlacklist = new Set([
   ..._tooManyPoints,
-  ..._defaultBlacklist
+  ..._defaultBlacklistNoBackgrounds
 ]);
 
 function isOkToReadBackgrounds(n: any) {
@@ -130,11 +144,17 @@ export function conditionalReadBlacklist(
     } else {
       return _okToReadDefsWithGeomBlacklist;
     }
-  } else {
+  } else if (isOkToReadBackgrounds(n)) {
     if (ignoreGeometry) {
       return _noGeometryBlacklist;
     } else {
       return _defaultBlacklist;
+    }
+  } else {
+    if (ignoreGeometry) {
+      return _noGeometryNoBackgroundsBlacklist;
+    } else {
+      return _defaultBlacklistNoBackgrounds;
     }
   }
 }

--- a/src/readBlacklist.ts
+++ b/src/readBlacklist.ts
@@ -52,6 +52,10 @@ const _textLayerWithGeomBlacklist = new Set([
   ..._defaultBlacklist
 ]);
 
+function isOkToReadBackgrounds(n: any) {
+  return "type" in n && n.type === "PAGE";
+}
+
 export function conditionalReadBlacklistSimple(
   n: any,
   options: Pick<Options, "geometry">
@@ -67,6 +71,11 @@ export function conditionalReadBlacklistSimple(
         (!n.parent || n.parent.type !== "COMPONENT_SET")));
   if (!okToReadDefs) {
     conditionalBlacklist.add("componentPropertyDefinitions");
+  }
+
+  if (!isOkToReadBackgrounds(n)) {
+    conditionalBlacklist.add("backgrounds");
+    conditionalBlacklist.add("backgroundStyleId");
   }
 
   // Ignore geometry keys if geometry is set to "none"

--- a/src/updateImageHashes.test.ts
+++ b/src/updateImageHashes.test.ts
@@ -2,26 +2,26 @@ import * as F from "./figma-json";
 import updateImageHashes from "./updateImageHashes";
 import defaultLayers from "./figma-default-layers";
 
-test("Updates background", () => {
+test("Updates fills", () => {
   const updates = new Map([["A", "B"]]);
   const bgFrame: F.FrameNode = {
     ...defaultLayers.FRAME,
-    backgrounds: [{ type: "IMAGE", imageHash: "A", scaleMode: "FILL" }]
+    fills: [{ type: "IMAGE", imageHash: "A", scaleMode: "FILL" }]
   };
   expect(updateImageHashes(bgFrame, updates)).toEqual({
     ...defaultLayers.FRAME,
-    backgrounds: [{ type: "IMAGE", imageHash: "B", scaleMode: "FILL" }]
+    fills: [{ type: "IMAGE", imageHash: "B", scaleMode: "FILL" }]
   });
 });
 
-test("Nulls missing background", () => {
+test("Nulls missing fills", () => {
   const emptyUpdates = new Map();
   const bgFrame: F.FrameNode = {
     ...defaultLayers.FRAME,
-    backgrounds: [{ type: "IMAGE", imageHash: "A", scaleMode: "FILL" }]
+    fills: [{ type: "IMAGE", imageHash: "A", scaleMode: "FILL" }]
   };
   expect(updateImageHashes(bgFrame, emptyUpdates)).toEqual({
     ...defaultLayers.FRAME,
-    backgrounds: [{ type: "IMAGE", imageHash: null, scaleMode: "FILL" }]
+    fills: [{ type: "IMAGE", imageHash: null, scaleMode: "FILL" }]
   });
 });

--- a/src/updateImageHashes.ts
+++ b/src/updateImageHashes.ts
@@ -39,10 +39,5 @@ export default function updateImageHashes(
     n.fills = fixFills(n.fills);
   }
 
-  // fix images in backgrounds
-  if ("backgrounds" in n && n.backgrounds !== undefined) {
-    n.backgrounds = fixFills(n.backgrounds);
-  }
-
   return n;
 }


### PR DESCRIPTION
## Changes
We weren't able to insert anything with `fills` (e.g. a blue rectangle) if the `backgrounds` property didn't match the fills. E.g. a default layer's empty backgrounds property would override any fills we were setting on the server, causing the fills to have no effect.

The solution is to no longer read `backgrounds` because it's deprecated in favor of `fills`. This will remove it from the default layers. We'll only read it for Pages, because they're the only nodes for which it (strangely) isn't deprecated.

Aside: I appreciate that we're making the conditionalBlacklist fast by making sure all blacklists are cacheable, but it does make maintenance painful.

## Test plan
- Tests
- Manual testing